### PR TITLE
Fix Minecraft#isHudHidden name

### DIFF
--- a/mappings/net/minecraft/client/Minecraft.mapping
+++ b/mappings/net/minecraft/client/Minecraft.mapping
@@ -86,7 +86,7 @@ CLASS net/minecraft/client/Minecraft net/minecraft/client/Minecraft
 	METHOD method_2142 getDebugSecondLine ()Ljava/lang/String;
 	METHOD method_2143 getDebugFourthLine ()Ljava/lang/String;
 	METHOD method_2144 getDebugThirdLine ()Ljava/lang/String;
-	METHOD method_2146 isHudHidden ()Z
+	METHOD method_2146 isHudShown ()Z
 	METHOD method_2147 isFancyGraphicsEnabled ()Z
 	METHOD method_2148 isSmoothLightingEnabled ()Z
 	METHOD method_2149 isDebugHudEnabled ()Z


### PR DESCRIPTION
For more reference, see #70 
Fixes #70 